### PR TITLE
chore: throttle Dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "America/Sao_Paulo"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     labels:
       - "dependencies"
       - "npm"
@@ -32,6 +36,10 @@ updates:
         dependency-type: "development"
         update-types:
           - "major"
+    ignore:
+      - dependency-name: "react-day-picker"
+        versions:
+          - ">=9.14.0"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -40,7 +48,7 @@ updates:
       day: "monday"
       time: "08:30"
       timezone: "America/Sao_Paulo"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary
- cap version-update PRs to one open PR per ecosystem
- add a cooldown window to reduce immediate Dependabot churn after releases
- keep react-day-picker pinned below 9.14.0 to avoid reintroducing the unreviewed transitive dependency

## Validation
- YAML parsed locally
- dependabot config will be validated by GitHub on the PR

## Summary by Sourcery

Throttle automated dependency update pull requests and introduce safeguards around specific packages in Dependabot configuration.

Build:
- Reduce open Dependabot pull requests to one per ecosystem and add cooldown periods for major, minor, and patch releases in the npm config.
- Pin react-day-picker below version 9.14.0 in Dependabot to avoid updating to undesired versions.
- Reduce open Dependabot pull requests to one for GitHub Actions updates.