### PR TITLE
fix: align branch protection with GitHub check runs

### DIFF
--- a/scripts/harden-github-repo.sh
+++ b/scripts/harden-github-repo.sh
@@ -71,11 +71,23 @@ cat >"${tmp_payload}" <<EOF
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": [
-      "CI / Lint, Test and Build (Node 20.x) (pull_request)",
-      "CI / Lint, Test and Build (Node 22.x) (pull_request)",
-      "CodeQL / Analyze (javascript-typescript) (javascript-typescript) (pull_request)",
-      "Dependency Review / Check dependency changes (pull_request)"
+    "checks": [
+      {
+        "context": "Lint, Test and Build (Node 20.x)",
+        "app_id": 15368
+      },
+      {
+        "context": "Lint, Test and Build (Node 22.x)",
+        "app_id": 15368
+      },
+      {
+        "context": "Analyze (javascript-typescript) (javascript-typescript)",
+        "app_id": 15368
+      },
+      {
+        "context": "Check dependency changes",
+        "app_id": 15368
+      }
     ]
   },
   "enforce_admins": false,


### PR DESCRIPTION
## Summary
- align required branch protection checks with actual GitHub Actions check-run names
- use explicit `checks` entries with the GitHub Actions app id
- prevent branch protection from requiring non-existent legacy status contexts

## Validation
- bash -n scripts/harden-github-repo.sh
- ./scripts/harden-github-repo.sh
- gh pr view 26 --json mergeStateStatus,mergeable

## Summary by Sourcery

Align repository hardening script with current GitHub branch protection check-run configuration.

Build:
- Update branch protection payload in hardening script to use explicit GitHub Actions check-run entries with app IDs instead of legacy status contexts.

Chores:
- Remove references to non-existent legacy status contexts from branch protection configuration in the repository hardening script.